### PR TITLE
Bunch of fixes

### DIFF
--- a/src/ITCC.HTTP.API/Attributes/ApiViewCheckAttribute.cs
+++ b/src/ITCC.HTTP.API/Attributes/ApiViewCheckAttribute.cs
@@ -1,6 +1,7 @@
 ﻿// This is an open source non-commercial project. Dear PVS-Studio, please check it.
 // PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
 using System;
+using System.Runtime.CompilerServices;
 
 namespace ITCC.HTTP.API.Attributes
 {
@@ -15,7 +16,7 @@ namespace ITCC.HTTP.API.Attributes
     [AttributeUsage(AttributeTargets.Method)]
     public class ApiViewCheckAttribute : Attribute
     {
-        public ApiViewCheckAttribute(string checkDescription = null)
+        public ApiViewCheckAttribute([CallerMemberName] string checkDescription = null)
         {
             CheckDescription = checkDescription;
         }

--- a/src/ITCC.HTTP.Server/Core/AcceptType.cs
+++ b/src/ITCC.HTTP.Server/Core/AcceptType.cs
@@ -40,8 +40,7 @@ namespace ITCC.HTTP.Server.Core
                 if (!qPart.StartsWith("q="))
                     return null;
 
-                double qValue;
-                if (!double.TryParse(qPart.Substring(2), out qValue))
+                if (!double.TryParse(qPart.Substring(2), out double qValue))
                     return null;
 
                 result.Qvalue = qValue;

--- a/src/ITCC.HTTP.Server/Core/HttpServerConfiguration.cs
+++ b/src/ITCC.HTTP.Server/Core/HttpServerConfiguration.cs
@@ -174,6 +174,16 @@ namespace ITCC.HTTP.Server.Core
         ///     Memory pressure alarm interval startegy
         /// </summary>
         public MemoryAlarmStrategy MemoryAlarmStrategy { get; set; } = MemoryAlarmStrategy.Fibonacci;
+   
+        /// <summary>
+        ///     If true, server lifecycle event will be written in debug log
+        /// </summary>
+        public bool DebugLogsEnabled { get; set; }
+
+        /// <summary>
+        ///     If true, server requests and responses will be written to trace log
+        /// </summary>
+        public bool RequestTracingEnabled { get; set; }
 
         public bool IsEnough()
         {

--- a/src/ITCC.HTTP.Server/Core/ResponseFactory.cs
+++ b/src/ITCC.HTTP.Server/Core/ResponseFactory.cs
@@ -87,7 +87,7 @@ namespace ITCC.HTTP.Server.Core
 
             if (body == null)
             {
-                Logger.LogTrace("RESP FACTORY", $"Response built: \n{SerializeResponse(httpResponse, null)}");
+                Logger.LogEntry("RESP FACTORY", LogLevel.Trace, $"Response built: \n{SerializeResponse(httpResponse, null)}");
                 return;
             }
 
@@ -120,7 +120,7 @@ namespace ITCC.HTTP.Server.Core
 
             SetResponseBody(context, encoder, bodyString);
 
-            Logger.LogTrace("RESP FACTORY", $"Response built: \n{SerializeResponse(httpResponse, isHeadRequest ? null : bodyString)}");
+            Logger.LogEntry("RESP FACTORY", LogLevel.Trace, $"Response built: \n{SerializeResponse(httpResponse, isHeadRequest ? null : bodyString)}");
         }
 
         public static string SerializeResponse(HttpListenerResponse response, string bodyString)

--- a/src/ITCC.HTTP.Server/Core/ResponseFactory.cs
+++ b/src/ITCC.HTTP.Server/Core/ResponseFactory.cs
@@ -1,5 +1,6 @@
 ﻿// This is an open source non-commercial project. Dear PVS-Studio, please check it.
 // PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -20,13 +21,12 @@ namespace ITCC.HTTP.Server.Core
     {
         #region public
 
-        public static bool SetCommonHeaders(IDictionary<string, string> headers)
+        public static void SetCommonHeaders(IDictionary<string, string> headers)
         {
             if (headers == null)
-                return false;
+                return;
 
             _commonHeaders = new Dictionary<string, string>(headers);
-            return true;
         }
 
         public static void SetBodyEncoders(List<IBodyEncoder> encoders)
@@ -76,7 +76,6 @@ namespace ITCC.HTTP.Server.Core
             IDictionary<string, string> additionalHeaders = null, bool alreadyEncoded = false)
         {
             var httpResponse = context.Response;
-            // ReSharper disable once RedundantAssignment
             var isHeadRequest = context.Request.HttpMethod.ToUpperInvariant() == "HEAD";
             httpResponse.StatusCode = (int) code;
             httpResponse.StatusDescription = SelectReasonPhrase(code);

--- a/src/ITCC.HTTP.Server/Core/ResponseFactory.cs
+++ b/src/ITCC.HTTP.Server/Core/ResponseFactory.cs
@@ -98,7 +98,7 @@ namespace ITCC.HTTP.Server.Core
                 httpResponse.StatusDescription = SelectReasonPhrase(HttpStatusCode.NotAcceptable);
                 SetResponseBody(context, _defaultEncoder, _defaultEncoder.Serialize(_supportedContentTypes));
                 if (RequestTracingEnabled)
-                    Logger.LogTrace("RESP FACTORY", $"Response built: \n{SerializeResponse(httpResponse, null)}");
+                    Logger.LogEntry("RESP FACTORY", LogLevel.Trace, $"Response built: \n{SerializeResponse(httpResponse, null)}");
                 return;
             }
 

--- a/src/ITCC.HTTP.Server/Core/ResponseFactory.cs
+++ b/src/ITCC.HTTP.Server/Core/ResponseFactory.cs
@@ -86,7 +86,8 @@ namespace ITCC.HTTP.Server.Core
 
             if (body == null)
             {
-                Logger.LogEntry("RESP FACTORY", LogLevel.Trace, $"Response built: \n{SerializeResponse(httpResponse, null)}");
+                if (RequestTracingEnabled)
+                    Logger.LogEntry("RESP FACTORY", LogLevel.Trace, $"Response built: \n{SerializeResponse(httpResponse, null)}");
                 return;
             }
 
@@ -96,7 +97,8 @@ namespace ITCC.HTTP.Server.Core
                 httpResponse.StatusCode = (int)HttpStatusCode.NotAcceptable;
                 httpResponse.StatusDescription = SelectReasonPhrase(HttpStatusCode.NotAcceptable);
                 SetResponseBody(context, _defaultEncoder, _defaultEncoder.Serialize(_supportedContentTypes));
-                Logger.LogTrace("RESP FACTORY", $"Response built: \n{SerializeResponse(httpResponse, null)}");
+                if (RequestTracingEnabled)
+                    Logger.LogTrace("RESP FACTORY", $"Response built: \n{SerializeResponse(httpResponse, null)}");
                 return;
             }
 
@@ -119,7 +121,8 @@ namespace ITCC.HTTP.Server.Core
 
             SetResponseBody(context, encoder, bodyString);
 
-            Logger.LogEntry("RESP FACTORY", LogLevel.Trace, $"Response built: \n{SerializeResponse(httpResponse, isHeadRequest ? null : bodyString)}");
+            if (RequestTracingEnabled)
+                Logger.LogEntry("RESP FACTORY", LogLevel.Trace, $"Response built: \n{SerializeResponse(httpResponse, isHeadRequest ? null : bodyString)}");
         }
 
         public static string SerializeResponse(HttpListenerResponse response, string bodyString)
@@ -172,6 +175,7 @@ namespace ITCC.HTTP.Server.Core
         
         public static List<Type> NonSerializableTypes = new List<Type>();
         public static bool LogResponseBodies = true;
+        public static bool RequestTracingEnabled = false;
         public static int ResponseBodyLogLimit = -1;
         public static readonly List<Tuple<string, string>> LogBodyReplacePatterns = new List<Tuple<string, string>>();
         public static readonly List<string> LogProhibitedHeaders = new List<string>();

--- a/src/ITCC.HTTP.Server/Core/StaticServer.cs
+++ b/src/ITCC.HTTP.Server/Core/StaticServer.cs
@@ -1,9 +1,5 @@
 ﻿// This is an open source non-commercial project. Dear PVS-Studio, please check it.
 // PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
-#if TRACE
-    #define ITCC_LOG_REQUEST_BODIES
-#endif
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/ITCC.HTTP.Server/Core/StaticServer.cs
+++ b/src/ITCC.HTTP.Server/Core/StaticServer.cs
@@ -603,8 +603,7 @@ namespace ITCC.HTTP.Server.Core
             var localUri = request.Url.LocalPath.Trim('/');
             if (requestMethod == HttpMethod.Get || requestMethod == HttpMethod.Head)
             {
-                string redirectionTarget;
-                if (InnerStaticRedirectionTable.TryGetValue(localUri, out redirectionTarget))
+                if (InnerStaticRedirectionTable.TryGetValue(localUri, out string redirectionTarget))
                 {
                     var correspondedProcessor =
                         InnerRequestProcessors.FirstOrDefault(

--- a/src/ITCC.HTTP.Server/Core/StaticServer.cs
+++ b/src/ITCC.HTTP.Server/Core/StaticServer.cs
@@ -137,6 +137,7 @@ namespace ITCC.HTTP.Server.Core
             ResponseFactory.NonSerializableTypes = configuration.NonSerializableTypes;
             ResponseFactory.SetBodyEncoders(configuration.BodyEncoders);
             ResponseFactory.LogResponseBodies = configuration.LogResponseBodies;
+            ResponseFactory.RequestTracingEnabled = configuration.RequestTracingEnabled;
             ResponseFactory.ResponseBodyLogLimit = configuration.ResponseBodyLogLimit;
             CommonHelper.SetSerializationLimitations(configuration.RequestBodyLogLimit,
                 configuration.LogProhibitedQueryParams,

--- a/src/ITCC.HTTP.Server/Files/FileRequestController.cs
+++ b/src/ITCC.HTTP.Server/Files/FileRequestController.cs
@@ -126,7 +126,7 @@ namespace ITCC.HTTP.Server.Files
         {
             if (!_started)
             {
-                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.NotImplemented, null);
+                ResponseFactory.BuildResponse(context, HttpStatusCode.NotImplemented, null);
                 return;
             }
 
@@ -137,7 +137,7 @@ namespace ITCC.HTTP.Server.Files
                 var section = ExtractFileSection(request.Url.LocalPath);
                 if (filename == null || section == null || filename.Contains("_CHANGED_"))
                 {
-                    ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.BadRequest, null);
+                    ResponseFactory.BuildResponse(context, HttpStatusCode.BadRequest, null);
                     return;
                 }
                 var filePath = FilesLocation + Path.DirectorySeparatorChar + section.Folder + Path.DirectorySeparatorChar + filename;
@@ -176,17 +176,17 @@ namespace ITCC.HTTP.Server.Files
                             HandleFileDeleteRequest(context, filePath);
                             return;
                         }
-                        ResponseFactory<TAccount>.BuildResponse(context,  HttpStatusCode.MethodNotAllowed, null);
+                        ResponseFactory.BuildResponse(context,  HttpStatusCode.MethodNotAllowed, null);
                         return;
                     default:
-                        ResponseFactory<TAccount>.BuildResponse(context, authResult);
+                        ResponseFactory.BuildResponse(context, authResult);
                         return;
                 }
             }
             catch (Exception exception)
             {
                 LogException(LogLevel.Warning, exception);
-                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.InternalServerError, null);
+                ResponseFactory.BuildResponse(context, HttpStatusCode.InternalServerError, null);
             }
         }
 
@@ -196,10 +196,10 @@ namespace ITCC.HTTP.Server.Files
             LogTrace($"Favicon requested, path: {FaviconPath}");
             if (string.IsNullOrEmpty(FaviconPath) || !File.Exists(FaviconPath))
             {
-                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.NotFound, null);
+                ResponseFactory.BuildResponse(context, HttpStatusCode.NotFound, null);
                 return;
             }
-            ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.OK, null);
+            ResponseFactory.BuildResponse(context, HttpStatusCode.OK, null);
             response.ContentType = "image/x-icon";
             using (var fileStream = new FileStream(FaviconPath, FileMode.Open, FileAccess.Read,
                 FileShare.ReadWrite))
@@ -366,7 +366,7 @@ namespace ITCC.HTTP.Server.Files
             if (FilesPreprocessingEnabled && FilePreprocessController.FileInProgress(filePath))
             {
                 LogDebug($"File {filePath} was requested but is in progress");
-                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.ServiceUnavailable, null);
+                ResponseFactory.BuildResponse(context, HttpStatusCode.ServiceUnavailable, null);
                 return;
             }
 
@@ -374,7 +374,7 @@ namespace ITCC.HTTP.Server.Files
             if (fileRequest == null) 
             {
                 LogDebug($"Failed to build file request for {filePath}");
-                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.BadRequest, null);
+                ResponseFactory.BuildResponse(context, HttpStatusCode.BadRequest, null);
                 return;
             }
             await fileRequest.BuildResponse(context);
@@ -385,14 +385,14 @@ namespace ITCC.HTTP.Server.Files
             if (FilesPreprocessingEnabled && FilePreprocessController.FileInProgress(filePath))
             {
                 LogDebug($"File {filePath} was requested but is in progress");
-                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.ServiceUnavailable, null);
+                ResponseFactory.BuildResponse(context, HttpStatusCode.ServiceUnavailable, null);
                 return Task.FromResult(0);
             }
 
             if (!File.Exists(filePath))
             {
                 LogDebug($"File {filePath} was requested but was not found");
-                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.NotFound, null);
+                ResponseFactory.BuildResponse(context, HttpStatusCode.NotFound, null);
                 return Task.FromResult(0);
             }
 
@@ -411,7 +411,7 @@ namespace ITCC.HTTP.Server.Files
             if (File.Exists(filePath))
             {
                 LogDebug($"File {filePath} already exists");
-                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.Conflict, null);
+                ResponseFactory.BuildResponse(context, HttpStatusCode.Conflict, null);
                 return;
             }
             var fileContent = context.Request.InputStream;
@@ -419,7 +419,7 @@ namespace ITCC.HTTP.Server.Files
             if (section.MaxFileSize > 0 && contentLength > section.MaxFileSize)
             {
                 LogDebug($"Trying to create file of size {contentLength} in section {section.Name} with max size of {section.MaxFileSize}");
-                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.RequestEntityTooLarge, null);
+                ResponseFactory.BuildResponse(context, HttpStatusCode.RequestEntityTooLarge, null);
                 return;
             }
             using (var file = new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite))
@@ -433,10 +433,10 @@ namespace ITCC.HTTP.Server.Files
             if (FilesPreprocessingEnabled)
             {
                 var code = FilePreprocessController.EnqueueFile(filePath) ? HttpStatusCode.Accepted : HttpStatusCode.Created;
-                ResponseFactory<TAccount>.BuildResponse(context, code, null);
+                ResponseFactory.BuildResponse(context, code, null);
             }
             else
-                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.Created, null);
+                ResponseFactory.BuildResponse(context, HttpStatusCode.Created, null);
         }
 
         private void HandleFileDeleteRequest(HttpListenerContext context, string filePath)
@@ -444,7 +444,7 @@ namespace ITCC.HTTP.Server.Files
             if (!File.Exists(filePath))
             {
                 LogDebug($"File {filePath} does not exist and cannot be deleted");
-                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.NotFound, null);
+                ResponseFactory.BuildResponse(context, HttpStatusCode.NotFound, null);
                 return;
             }
 
@@ -454,12 +454,12 @@ namespace ITCC.HTTP.Server.Files
             {
                 File.Delete(filePath);
                 compressed.ForEach(File.Delete);
-                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.OK, null);
+                ResponseFactory.BuildResponse(context, HttpStatusCode.OK, null);
             }
             catch (Exception ex)
             {
                 LogException(LogLevel.Warning, ex);
-                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.InternalServerError, null);
+                ResponseFactory.BuildResponse(context, HttpStatusCode.InternalServerError, null);
             }
         }
 

--- a/src/ITCC.HTTP.Server/Files/FileRequestController.cs
+++ b/src/ITCC.HTTP.Server/Files/FileRequestController.cs
@@ -126,7 +126,7 @@ namespace ITCC.HTTP.Server.Files
         {
             if (!_started)
             {
-                ResponseFactory.BuildResponse(context, HttpStatusCode.NotImplemented, null);
+                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.NotImplemented, null);
                 return;
             }
 
@@ -137,7 +137,7 @@ namespace ITCC.HTTP.Server.Files
                 var section = ExtractFileSection(request.Url.LocalPath);
                 if (filename == null || section == null || filename.Contains("_CHANGED_"))
                 {
-                    ResponseFactory.BuildResponse(context, HttpStatusCode.BadRequest, null);
+                    ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.BadRequest, null);
                     return;
                 }
                 var filePath = FilesLocation + Path.DirectorySeparatorChar + section.Folder + Path.DirectorySeparatorChar + filename;
@@ -176,17 +176,17 @@ namespace ITCC.HTTP.Server.Files
                             HandleFileDeleteRequest(context, filePath);
                             return;
                         }
-                        ResponseFactory.BuildResponse(context,  HttpStatusCode.MethodNotAllowed, null);
+                        ResponseFactory<TAccount>.BuildResponse(context,  HttpStatusCode.MethodNotAllowed, null);
                         return;
                     default:
-                        ResponseFactory.BuildResponse(context, authResult);
+                        ResponseFactory<TAccount>.BuildResponse(context, authResult);
                         return;
                 }
             }
             catch (Exception exception)
             {
                 LogException(LogLevel.Warning, exception);
-                ResponseFactory.BuildResponse(context, HttpStatusCode.InternalServerError, null);
+                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.InternalServerError, null);
             }
         }
 
@@ -196,10 +196,10 @@ namespace ITCC.HTTP.Server.Files
             LogTrace($"Favicon requested, path: {FaviconPath}");
             if (string.IsNullOrEmpty(FaviconPath) || !File.Exists(FaviconPath))
             {
-                ResponseFactory.BuildResponse(context, HttpStatusCode.NotFound, null);
+                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.NotFound, null);
                 return;
             }
-            ResponseFactory.BuildResponse(context, HttpStatusCode.OK, null);
+            ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.OK, null);
             response.ContentType = "image/x-icon";
             using (var fileStream = new FileStream(FaviconPath, FileMode.Open, FileAccess.Read,
                 FileShare.ReadWrite))
@@ -366,7 +366,7 @@ namespace ITCC.HTTP.Server.Files
             if (FilesPreprocessingEnabled && FilePreprocessController.FileInProgress(filePath))
             {
                 LogDebug($"File {filePath} was requested but is in progress");
-                ResponseFactory.BuildResponse(context, HttpStatusCode.ServiceUnavailable, null);
+                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.ServiceUnavailable, null);
                 return;
             }
 
@@ -374,7 +374,7 @@ namespace ITCC.HTTP.Server.Files
             if (fileRequest == null) 
             {
                 LogDebug($"Failed to build file request for {filePath}");
-                ResponseFactory.BuildResponse(context, HttpStatusCode.BadRequest, null);
+                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.BadRequest, null);
                 return;
             }
             await fileRequest.BuildResponse(context);
@@ -385,14 +385,14 @@ namespace ITCC.HTTP.Server.Files
             if (FilesPreprocessingEnabled && FilePreprocessController.FileInProgress(filePath))
             {
                 LogDebug($"File {filePath} was requested but is in progress");
-                ResponseFactory.BuildResponse(context, HttpStatusCode.ServiceUnavailable, null);
+                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.ServiceUnavailable, null);
                 return Task.FromResult(0);
             }
 
             if (!File.Exists(filePath))
             {
                 LogDebug($"File {filePath} was requested but was not found");
-                ResponseFactory.BuildResponse(context, HttpStatusCode.NotFound, null);
+                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.NotFound, null);
                 return Task.FromResult(0);
             }
 
@@ -411,7 +411,7 @@ namespace ITCC.HTTP.Server.Files
             if (File.Exists(filePath))
             {
                 LogDebug($"File {filePath} already exists");
-                ResponseFactory.BuildResponse(context, HttpStatusCode.Conflict, null);
+                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.Conflict, null);
                 return;
             }
             var fileContent = context.Request.InputStream;
@@ -419,7 +419,7 @@ namespace ITCC.HTTP.Server.Files
             if (section.MaxFileSize > 0 && contentLength > section.MaxFileSize)
             {
                 LogDebug($"Trying to create file of size {contentLength} in section {section.Name} with max size of {section.MaxFileSize}");
-                ResponseFactory.BuildResponse(context, HttpStatusCode.RequestEntityTooLarge, null);
+                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.RequestEntityTooLarge, null);
                 return;
             }
             using (var file = new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite))
@@ -433,10 +433,10 @@ namespace ITCC.HTTP.Server.Files
             if (FilesPreprocessingEnabled)
             {
                 var code = FilePreprocessController.EnqueueFile(filePath) ? HttpStatusCode.Accepted : HttpStatusCode.Created;
-                ResponseFactory.BuildResponse(context, code, null);
+                ResponseFactory<TAccount>.BuildResponse(context, code, null);
             }
             else
-                ResponseFactory.BuildResponse(context, HttpStatusCode.Created, null);
+                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.Created, null);
         }
 
         private void HandleFileDeleteRequest(HttpListenerContext context, string filePath)
@@ -444,7 +444,7 @@ namespace ITCC.HTTP.Server.Files
             if (!File.Exists(filePath))
             {
                 LogDebug($"File {filePath} does not exist and cannot be deleted");
-                ResponseFactory.BuildResponse(context, HttpStatusCode.NotFound, null);
+                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.NotFound, null);
                 return;
             }
 
@@ -454,12 +454,12 @@ namespace ITCC.HTTP.Server.Files
             {
                 File.Delete(filePath);
                 compressed.ForEach(File.Delete);
-                ResponseFactory.BuildResponse(context, HttpStatusCode.OK, null);
+                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.OK, null);
             }
             catch (Exception ex)
             {
                 LogException(LogLevel.Warning, ex);
-                ResponseFactory.BuildResponse(context, HttpStatusCode.InternalServerError, null);
+                ResponseFactory<TAccount>.BuildResponse(context, HttpStatusCode.InternalServerError, null);
             }
         }
 

--- a/src/ITCC.HTTP.Server/Files/FileTypeSelector.cs
+++ b/src/ITCC.HTTP.Server/Files/FileTypeSelector.cs
@@ -24,8 +24,7 @@ namespace ITCC.HTTP.Server.Files
                 return FileType.Default;
             lock (DictLock)
             {
-                FileType result;
-                if (FileTypeDictionary.TryGetValue(extension, out result)) 
+                if (FileTypeDictionary.TryGetValue(extension, out FileType result))
                     return result;
             }
             return FileType.Default;

--- a/src/ITCC.HTTP.Server/Files/Preprocess/FilePreprocessorThread.cs
+++ b/src/ITCC.HTTP.Server/Files/Preprocess/FilePreprocessorThread.cs
@@ -75,8 +75,7 @@ namespace ITCC.HTTP.Server.Files.Preprocess
                         }
                     }
 
-                    BaseFilePreprocessTask task;
-                    if (!_taskQueue.TryDequeue(out task))
+                    if (!_taskQueue.TryDequeue(out BaseFilePreprocessTask task))
                     {
                         Thread.Sleep(Constants.FilesPreprocessorThreadSleepInterval);
                         continue;

--- a/src/ITCC.HTTP.Server/Files/Preprocess/ImagePreprocessTask.cs
+++ b/src/ITCC.HTTP.Server/Files/Preprocess/ImagePreprocessTask.cs
@@ -35,11 +35,10 @@ namespace ITCC.HTTP.Server.Files.Preprocess
 
                 LogDebug($"Processing image {FileName}. Original resolution {(int) originalWidth}x{(int) originalHeight}");
 
-                ImageFormat format;
                 var extension = IoHelper.GetExtension(FileName);
                 if (extension == null)
                     return true;
-                if (!ImageFormatDictionary.TryGetValue(extension, out format))
+                if (!ImageFormatDictionary.TryGetValue(extension, out ImageFormat format))
                 {
                     LogMessage(LogLevel.Warning, $"Unknown image format: {extension}");
                     return false;

--- a/src/ITCC.HTTP.Server/Files/Requests/BaseFileRequest.cs
+++ b/src/ITCC.HTTP.Server/Files/Requests/BaseFileRequest.cs
@@ -194,8 +194,7 @@ namespace ITCC.HTTP.Server.Files.Requests
             if (request.QueryString[paramName] == null)
                 return true;
 
-            int value;
-            if (! int.TryParse(request.QueryString[paramName], out value))
+            if (!int.TryParse(request.QueryString[paramName], out int value))
                 return false;
             try
             {
@@ -220,13 +219,11 @@ namespace ITCC.HTTP.Server.Files.Requests
             var parts = targetPart.Split('x');
             if (parts.Length != 2)
                 return InvalidResolutionTuple();
-            int width;
-            int height;
-            if (!int.TryParse(parts[0], out width))
+            if (!int.TryParse(parts[0], out int width))
                 return InvalidResolutionTuple();
             if (width < 0)
                 return InvalidResolutionTuple();
-            if (!int.TryParse(parts[1], out height))
+            if (!int.TryParse(parts[1], out int height))
                 return InvalidResolutionTuple();
             if (height < 0)
                 return InvalidResolutionTuple();

--- a/src/ITCC.HTTP.Server/README.md
+++ b/src/ITCC.HTTP.Server/README.md
@@ -110,6 +110,18 @@ double RequestMaxServeTime { get; set; } = 1;                                   
 int CriticalMemoryValue { get; set; } = -1;                                       // Размер памяти процесса в мегабайтах, после которого выдается предупреждение. Отрицательные значения - предупреждения не выдаются
 MemoryAlarmStrategy MemoryAlarmStrategy { get; set; }                             // Стратегия задания интервалов предупреждений об избыточном потреблении памяти 
 = MemoryAlarmStrategy.Fibonacci;
+
+/*
+Включать ли отладочный вывод о событиях на сервере (через `ITCC.Logging.Logger`, уровень `Debug`)
+**Можно менять в рантайме**
+*/
+bool DebugLogsEnabled { get; set; }      
+/*
+Логгировать ли все запросы к серверу и ответы сервера (через `ITCC.Logging.Logger`, уровень `Trace`).
+Оказывает **сильное** влияние на производительность.
+**Можно менять в рантайме**
+*/
+bool RequestTracingEnabled { get; set; }
 ```
 
 #### `static class MimeTypes`
@@ -160,6 +172,17 @@ Stream GetFileStream(string sectionName, string filename);                      
 Task<string> GetFileString(string sectionName, string filename);                          // Получение содержимого файла в виде строки.
 Task<FileOperationStatus> AddFile(string sectionName, string filename, Stream content);   // Добавление файла на сервер
 FileOperationStatus DeleteFile(string sectionName, string filename);                      // Удаление файла
+```
+
+Свойства:
+
+```
+bool DebugLogsEnabled { get; set; }      // Включать ли отладочный вывод о событиях на сервере (через `ITCC.Logging.Logger`, уровень `Debug`)
+/*
+Логгировать ли все запросы к серверу и ответы сервера (через `ITCC.Logging.Logger`, уровень `Trace`).
+Оказывает **сильное** влияние на производительность
+*/
+bool RequestTracingEnabled { get; set; } 
 ```
 
 ### Encoders

--- a/src/ITCC.HTTP.Server/Service/ServerStatistics.cs
+++ b/src/ITCC.HTTP.Server/Service/ServerStatistics.cs
@@ -152,13 +152,9 @@ namespace ITCC.HTTP.Server.Service
         {
             lock (_threadsLock)
             {
-                int totalWorkerThreads;
-                int totalIocpThreads;
-                int availableWorkerThreads;
-                int availableIocpThreads;
                 Thread.MemoryBarrier();
-                ThreadPool.GetMaxThreads(out totalWorkerThreads, out totalIocpThreads);
-                ThreadPool.GetAvailableThreads(out availableWorkerThreads, out availableIocpThreads);
+                ThreadPool.GetMaxThreads(out int totalWorkerThreads, out int totalIocpThreads);
+                ThreadPool.GetAvailableThreads(out int availableWorkerThreads, out int availableIocpThreads);
                 Thread.MemoryBarrier();
 
                 _currentWorkerThreads = totalWorkerThreads - availableWorkerThreads;
@@ -283,11 +279,9 @@ namespace ITCC.HTTP.Server.Service
                 uris.ForEach(u =>
                 {
                     var methodDict = _requestMethodCounters[u];
-                    double totalSuccessTime;
-                    double totalFailTime;
-                    if (!_requestSuccessTimeCounters.TryGetValue(u, out totalSuccessTime))
+                    if (!_requestSuccessTimeCounters.TryGetValue(u, out double totalSuccessTime))
                         totalSuccessTime = 0;
-                    if (!_requestFailTimeCounters.TryGetValue(u, out totalFailTime))
+                    if (!_requestFailTimeCounters.TryGetValue(u, out double totalFailTime))
                         totalFailTime = 0;
                     double averageSuccessTime;
                     double averageFailTime;

--- a/src/ITCC.HTTP.Server/Service/ServerStatistics.cs
+++ b/src/ITCC.HTTP.Server/Service/ServerStatistics.cs
@@ -152,7 +152,6 @@ namespace ITCC.HTTP.Server.Service
         {
             lock (_threadsLock)
             {
-                _threadingSamples++;
                 int totalWorkerThreads;
                 int totalIocpThreads;
                 int availableWorkerThreads;

--- a/src/ITCC.Logging.Windows/Loggers/EmailLogger.cs
+++ b/src/ITCC.Logging.Windows/Loggers/EmailLogger.cs
@@ -70,9 +70,15 @@ namespace ITCC.Logging.Windows.Loggers
             _updateTimer.AutoReset = true;
             FlushAsync(EmailLoggerFlushReason.LoggerStarted).Wait();
             _updateTimer.Start();
+
+            _running = true;
         }
 
-        public void Stop() => _updateTimer.Stop();
+        public void Stop()
+        {
+            _running = false;
+            _updateTimer.Stop();
+        } 
 
         public string Login { get; private set; }
 
@@ -127,6 +133,9 @@ namespace ITCC.Logging.Windows.Loggers
 
         private async Task FlushAndRestartTimerAsync(EmailLoggerFlushReason reason)
         {
+            if (! _running)
+                return;
+
             _updateTimer.Stop();
             await FlushAsync(reason);
             _updateTimer.Start();
@@ -230,6 +239,8 @@ namespace ITCC.Logging.Windows.Loggers
         private readonly ConcurrentQueue<LogEntryEventArgs> _messageQueue = new ConcurrentQueue<LogEntryEventArgs>();
 
         private bool _flushInProgress;
+
+        private volatile bool _running;
 
         #endregion
     }


### PR DESCRIPTION
Changelog notes:

* **New** : `DebugLogsEnabled` and `RequestTracingEnabled` added to `StaticServer` (can be turned on during startup via config and changed in runtime)  
* **Fix** : Do not throw in Logger::FlushAsync if email logger is registered but not started  
* **Fix** : Pass `checkDescription` to `ApiViewCheckAttribute` via `CallerMemberName`  
* **Fix** : Thread pool usage statistics fixed in `StaticServer`

@vladislav-prishchepa pls review and bump nuget version. It's not urgent but may be useful

New server logging can be turned on even in release mode in order to have A LOT of tracing info. It also does not hurt performance much when turned off